### PR TITLE
add support for float64 fields

### DIFF
--- a/errors.go
+++ b/errors.go
@@ -21,6 +21,10 @@ func errIntFormat() Error {
 	return errors.New("not a valid integer")
 }
 
+func errFloatFormat() Error {
+	return errors.New("not a valid number")
+}
+
 func errMustBeGreaterThanZero() Error {
 	return errors.New("value must be greater than zero")
 }

--- a/opt_float64.go
+++ b/opt_float64.go
@@ -1,0 +1,90 @@
+package configtypes
+
+import (
+	"encoding/json"
+	"strconv"
+
+	"gopkg.in/launchdarkly/go-sdk-common.v2/ldvalue"
+)
+
+// OptFloat64 represents an optional float64 parameter.
+//
+// In Go, an unset float64 normally defaults to zero. This type allows application code to distinguish
+// between zero and the absence of a value, in case some other default behavior is desired.
+//
+// When converting to or from JSON, the value must be either a JSON null or a JSON number.
+//
+// See the package documentation for the general contract for methods that have no specific documentation
+// here.
+type OptFloat64 struct {
+	hasValue bool
+	value    float64
+}
+
+func NewOptFloat64(value float64) OptFloat64 {
+	return OptFloat64{hasValue: true, value: value}
+}
+
+func NewOptFloat64FromString(s string) (OptFloat64, error) {
+	if s == "" {
+		return OptFloat64{}, nil
+	}
+	n, err := strconv.ParseFloat(s, 64)
+	if err != nil {
+		return OptFloat64{}, errFloatFormat()
+	}
+	return NewOptFloat64(n), nil
+}
+
+func (o OptFloat64) IsDefined() bool {
+	return o.hasValue
+}
+
+func (o OptFloat64) GetOrElse(orElseValue float64) float64 {
+	if o.hasValue {
+		return o.value
+	}
+	return orElseValue
+}
+
+func (o OptFloat64) String() string {
+	if o.hasValue {
+		return strconv.FormatFloat(o.value, 'f', -1, 64)
+	}
+	return ""
+}
+
+func (o OptFloat64) MarshalText() ([]byte, error) {
+	return []byte(o.String()), nil
+}
+
+func (o *OptFloat64) UnmarshalText(data []byte) error {
+	value, err := NewOptFloat64FromString(string(data))
+	if err == nil {
+		*o = value
+	}
+	return err
+}
+
+func (o OptFloat64) MarshalJSON() ([]byte, error) {
+	if o.hasValue {
+		return json.Marshal(o.value)
+	}
+	return json.Marshal(nil)
+}
+
+func (o *OptFloat64) UnmarshalJSON(data []byte) error {
+	var v ldvalue.Value
+	if err := v.UnmarshalJSON(data); err != nil {
+		return err
+	}
+	switch {
+	case v.IsNull():
+		*o = OptFloat64{}
+	case v.IsNumber():
+		*o = NewOptFloat64(v.Float64Value())
+	default:
+		return errFloatFormat()
+	}
+	return nil
+}

--- a/opt_float64_test.go
+++ b/opt_float64_test.go
@@ -1,0 +1,61 @@
+package configtypes
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestOptFloat64(t *testing.T) {
+	t.Run("empty value", func(t *testing.T) {
+		unsetValue := OptFloat64{}
+		assertIsDefined(t, false, unsetValue)
+		assert.Equal(t, float64(999), unsetValue.GetOrElse(999))
+	})
+
+	t.Run("defined value", func(t *testing.T) {
+		zeroValue := NewOptFloat64(0)
+		assertIsDefined(t, true, zeroValue)
+		assert.Equal(t, float64(0), zeroValue.GetOrElse(999))
+
+		negativeValue := NewOptFloat64(-1)
+		assertIsDefined(t, true, negativeValue)
+		assert.Equal(t, float64(-1), negativeValue.GetOrElse(999))
+
+		oneValue := NewOptFloat64(1.5)
+		assertIsDefined(t, true, oneValue)
+		assert.Equal(t, float64(1.5), oneValue.GetOrElse(0))
+	})
+
+	stringCtor := func(input string) (interface{}, error) {
+		o, err := NewOptFloat64FromString(input)
+		return o, err
+	}
+
+	assertConvertToText(t, map[string]textMarshalerAndStringer{
+		"": OptFloat64{}, "0": NewOptFloat64(0), "1.5": NewOptFloat64(1.5),
+		"100": NewOptFloat64(100), "-100": NewOptFloat64(-100),
+	})
+
+	assertConvertFromText(t, &OptFloat64{}, stringCtor, map[string]interface{}{
+		"": OptFloat64{}, "0": NewOptFloat64(0), "1.5": NewOptFloat64(1.5),
+		"100": NewOptFloat64(100), "-100": NewOptFloat64(-100),
+	})
+
+	assertConvertFromTextFails(t, &OptFloat64{}, stringCtor, errFloatFormat(),
+		"-", "x",
+	)
+
+	assertConvertToJSON(t, map[string]SingleValue{
+		`null`: OptFloat64{}, `0`: NewOptFloat64(0), `1.5`: NewOptFloat64(1.5),
+		`100`: NewOptFloat64(100), `-100`: NewOptFloat64(-100),
+	})
+
+	assertConvertFromJSON(t, &OptFloat64{}, map[string]interface{}{
+		`null`: OptFloat64{}, `0`: NewOptFloat64(0), `1.5`: NewOptFloat64(1.5),
+		`100`: NewOptFloat64(100), `-100`: NewOptFloat64(-100),
+	})
+
+	assertConvertFromJSONFails(t, &OptFloat64{},
+		`true`, `"x"`, `[]`, `{}`)
+}

--- a/var_reader.go
+++ b/var_reader.go
@@ -13,7 +13,8 @@ import (
 // translates them into values of any supported type. It accumulates errors as it goes.
 //
 // The supported types are any type that implements TextUnmarshaler (which includes all of the Opt
-// and Req types defined in this package), and also the primitive types bool, int, and string.
+// and Req types defined in this package), and also the primitive types bool, int, float64, and
+// string.
 //
 // You may specify the variable name for each target value programmatically, or use struct field
 // tags as described in ReadStruct(), or both.
@@ -248,6 +249,17 @@ func setterForTarget(target interface{}) func(data []byte) error {
 	case *int:
 		return func(data []byte) error {
 			var v OptInt
+			if err := v.UnmarshalText(data); err != nil {
+				return err
+			}
+			if v.IsDefined() {
+				*p = v.GetOrElse(0)
+			}
+			return nil
+		}
+	case *float64:
+		return func(data []byte) error {
+			var v OptFloat64
 			if err := v.UnmarshalText(data); err != nil {
 				return err
 			}

--- a/var_reader_test.go
+++ b/var_reader_test.go
@@ -46,27 +46,34 @@ func TestVarReader(t *testing.T) {
 
 	t.Run("reads into simple types", func(t *testing.T) {
 		r := NewVarReaderFromValues(map[string]string{
-			"BOOL":     "true",
-			"INT":      "1",
-			"STR":      "x",
-			"BAD_BOOL": "x",
-			"BAD_INT":  "1.5",
+			"BOOL":      "true",
+			"INT":       "1",
+			"FLOAT":     "1.5",
+			"STR":       "x",
+			"BAD_BOOL":  "x",
+			"BAD_INT":   "1.5",
+			"BAD_FLOAT": "x",
 		})
 		var b, bb bool
 		var i, bi int
+		var f, bf float64
 		var s string
 		assert.True(t, r.Read("BOOL", &b))
 		assert.True(t, r.Read("INT", &i))
+		assert.True(t, r.Read("FLOAT", &f))
 		assert.True(t, r.Read("STR", &s))
 		assert.True(t, r.Read("BAD_BOOL", &bb))
 		assert.True(t, r.Read("BAD_INT", &bi))
+		assert.True(t, r.Read("BAD_FLOAT", &bf))
 		assert.Equal(t, true, b)
 		assert.Equal(t, 1, i)
+		assert.Equal(t, float64(1.5), f)
 		assert.Equal(t, "x", s)
 		assert.Equal(t,
 			[]ValidationError{
 				{Path: ValidationPath{"BAD_BOOL"}, Err: errBoolFormat()},
 				{Path: ValidationPath{"BAD_INT"}, Err: errIntFormat()},
+				{Path: ValidationPath{"BAD_FLOAT"}, Err: errFloatFormat()},
 			},
 			r.Result().Errors(),
 		)


### PR DESCRIPTION
This isn't needed for ld-relay, but it makes sense to have (and we would need it if we started using the library in other internal projects).